### PR TITLE
DM-10093: Revert "Disable meas_modelfit until pybind11 wrapped"

### DIFF
--- a/ups/lsst_apps.table
+++ b/ups/lsst_apps.table
@@ -1,6 +1,5 @@
 setupRequired(meas_deblender)
-# temporarily disable meas_modelfit until pybind11 wrapped
-#setupRequired(meas_modelfit)
+setupRequired(meas_modelfit)
 setupRequired(pipe_tasks)
 setupRequired(obs_lsstSim)
 setupRequired(obs_sdss)


### PR DESCRIPTION
This reverts commit 041ae975d9c60a41b24488ec0ba1768431330fd8. meas_modelfit
was wrapped in DM-8465.