### PR TITLE
DM-14273: Add ap_verify to lsst_distrib

### DIFF
--- a/ups/lsst_apps.table
+++ b/ups/lsst_apps.table
@@ -1,6 +1,7 @@
 setupRequired(meas_deblender)
 setupRequired(meas_modelfit)
 setupRequired(pipe_tasks)
+setupRequired(ap_pipe)
 setupRequired(obs_lsstSim)
 setupRequired(obs_sdss)
 setupRequired(obs_test)


### PR DESCRIPTION
This PR adds `ap_pipe` (and its new dependencies `ap_association` and `dax_ppdb`) to `lsst_apps`.